### PR TITLE
Update BankAdapter.sol: Using 'immutable' for keccak variables

### DIFF
--- a/contracts/adapters/BankAdapter.sol
+++ b/contracts/adapters/BankAdapter.sol
@@ -34,9 +34,9 @@ SOFTWARE.
  */
 
 contract BankAdapterContract is AdapterGuard, Reimbursable {
-    bytes32 internal constant TokenName =
+    bytes32 internal immutable TokenName =
         keccak256("erc20.extension.tokenName");
-    bytes32 internal constant TokenSymbol =
+    bytes32 internal immutable TokenSymbol =
         keccak256("erc20.extension.tokenSymbol");
 
     /**


### PR DESCRIPTION
It's usually a gas saving practice to use `immutable` for keccak variables rather than `constant`

This explains better -> https://gist.github.com/grGred/9bab8b9bad0cd42fc23d4e31e7347144#change-constant-to-immutable-for-keccak-variables